### PR TITLE
Arm nun

### DIFF
--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -6,12 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ReflectionUtils;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.lang.reflect.Field;
@@ -78,6 +73,14 @@ public final class NeurodiversityController {
             }
         });
         return neurodivergencyRepository.save(existing);
+    }
+
+
+
+    @DeleteMapping("/api/v1/neurodiversity/{idNeurodiversity}")
+    public ResponseEntity<?> deleteById(@PathVariable final String idNeurodiversity){
+        neurodivergencyRepository.deleteById(idNeurodiversity);
+        return ResponseEntity.ok(null);
     }
     //      //
 }

--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -90,7 +90,8 @@ public final class NeurodiversityController {
         neurodivergencyRepository.deleteById(idNeurodiversity);
         return ResponseEntity.ok(null);
     }
-// filtrar por descripcion
+
+    // filtrar por descripcion
     @GetMapping("/api/v1/neurodiversities/description")
     public ResponseEntity<List<Neurodiversity>> getByDescription(@RequestParam("keyword") String keyword) {
         List<Neurodiversity> neuro = neurodivergencyRepository.findByDescriptionContaining(keyword);

--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import org.springframework.web.bind.annotation.RequestParam;
+
 import org.springframework.web.server.ResponseStatusException;
 
 import java.lang.reflect.Field;
@@ -88,5 +90,13 @@ public final class NeurodiversityController {
         neurodivergencyRepository.deleteById(idNeurodiversity);
         return ResponseEntity.ok(null);
     }
-    //      //
+// filtrar por descripcion
+    @GetMapping("/api/v1/neurodiversities/description")
+    public ResponseEntity<List<Neurodiversity>> getByDescription(@RequestParam("keyword") String keyword) {
+        List<Neurodiversity> neuro = neurodivergencyRepository.findByDescriptionContaining(keyword);
+        if (!neuro.isEmpty()) {
+            return ResponseEntity.ok(neuro);
+        }
+        return ResponseEntity.notFound().build();
+    }
 }

--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -93,7 +93,7 @@ public final class NeurodiversityController {
 
     // filtrar por descripcion
     @GetMapping("/api/v1/neurodiversities/description")
-    public ResponseEntity<List<Neurodiversity>> getByDescription(@RequestParam("keyword") String keyword) {
+    public ResponseEntity<List<Neurodiversity>> getByDescription(@RequestParam("keyword") final String keyword) {
         List<Neurodiversity> neuro = neurodivergencyRepository.findByDescriptionContaining(keyword);
         if (!neuro.isEmpty()) {
             return ResponseEntity.ok(neuro);

--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -6,7 +6,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ReflectionUtils;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.server.ResponseStatusException;
 
 import java.lang.reflect.Field;
@@ -55,7 +62,7 @@ public final class NeurodiversityController {
     // Put Request //
     @PutMapping("/api/v1/neurodiversity/edit/{id}")
     public ResponseEntity<Neurodiversity> updateN(@PathVariable(value = "id") final String id,
-           @RequestBody final Map<String, Object> fields) {
+                                                  @RequestBody final Map<String, Object> fields) {
         Neurodiversity updatedNeurodiversity = updateNeurodiversityFields(id, fields);
         neurodivergencyRepository.save(updatedNeurodiversity);
         return ResponseEntity.ok(updatedNeurodiversity);
@@ -76,9 +83,8 @@ public final class NeurodiversityController {
     }
 
 
-
     @DeleteMapping("/api/v1/neurodiversity/{idNeurodiversity}")
-    public ResponseEntity<?> deleteById(@PathVariable final String idNeurodiversity){
+    public ResponseEntity<?> deleteById(@PathVariable final String idNeurodiversity) {
         neurodivergencyRepository.deleteById(idNeurodiversity);
         return ResponseEntity.ok(null);
     }

--- a/src/main/java/bo/usfx/springneuroapi/repository/NeurodivergencyRepository.java
+++ b/src/main/java/bo/usfx/springneuroapi/repository/NeurodivergencyRepository.java
@@ -2,11 +2,15 @@ package bo.usfx.springneuroapi.repository;
 
 import bo.usfx.springneuroapi.model.Neurodiversity;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface NeurodivergencyRepository extends MongoRepository<Neurodiversity, String> {
 
     List<Neurodiversity> findByName(String name);
+
+    @Query("{'description': {$regex : ?0, $options: 'i'}}")
+    List<Neurodiversity> findByDescriptionContaining(String keyword);
 }
 


### PR DESCRIPTION
keyword search functionality in description
example :
you have the description:


"name": "schizophrenia",
        "description": "Schizophrenia is a **serious** mental illness that affects the way a person thinks, feels and behaves.",
...

**get**
http://localhost:8087/api/v1/neurodiversities/description?keyword=**serious**
 

**result:**

[
    {
        "id": "65a781a4d85b7d408aaaedcd",
        "name": "schizophrenia",
        "description": "Schizophrenia is a serious mental illness that affects the way a person thinks, feels and behaves.",
        "worldWidePercentage": "Between 10 and 12% of women between 35 and 84 years old have this disorder registered, and it reaches 16-18% when symptoms are included.",
        "basicExplanationLink": "https://www.nimh.nih.gov/health/publications/espanol/la-esquizofrenia#:~:text=La%20esquizofrenia%20es%20una%20enfermedad,ellas%2C%20sus%20familiares%20y%20amigos.",
        "testLink": "https://www.mayoclinic.org/es/diseases-conditions/schizophrenia/diagnosis-treatment/drc-20354449"
    }
]


the query works even if you only provide part of the description
and shows you all the matches in the database