### PR TITLE
Implement Initials-Based Filtering 

### DIFF
--- a/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
+++ b/src/main/java/bo/usfx/springneuroapi/controller/NeurodiversityController.java
@@ -10,9 +10,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import org.springframework.web.server.ResponseStatusException;
 
@@ -92,4 +93,21 @@ public final class NeurodiversityController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
         }
     }
+
+    //  @RequestParams  //
+
+    @GetMapping("/api/v1/neurodiversity")
+    public ResponseEntity<List<Neurodiversity>> getNeurodiversitiesBySubstring(
+            @RequestParam(required = false) final String name) {
+
+        List<Neurodiversity> neurodiversities;
+        if (name != null && !name.isEmpty()) {
+            neurodiversities = neurodivergencyRepository.findByNameStartingWithIgnoreCase(name);
+        } else {
+            neurodiversities = neurodivergencyRepository.findAll();
+        }
+        return new ResponseEntity<>(neurodiversities, HttpStatus.OK);
+    }
+
+    //  @RequestParams  //
 }

--- a/src/main/java/bo/usfx/springneuroapi/repository/NeurodivergencyRepository.java
+++ b/src/main/java/bo/usfx/springneuroapi/repository/NeurodivergencyRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 public interface NeurodivergencyRepository extends MongoRepository<Neurodiversity, String> {
 
     List<Neurodiversity> findByName(String name);
+
+    List<Neurodiversity> findByNameStartingWithIgnoreCase(String name);
 }
 


### PR DESCRIPTION
Added a screenshot showing the results of testing the 'getNeurodiversitiesBySubstring' endpoint with a 'name' query parameter set to 'd'. The test successfully retrieves neurodiversity entries that start with the letter 'd'.
![image](https://github.com/SoftwareDevFundamentals/NeuroDevAPI/assets/102622990/3e33de40-f407-4dde-95a1-e8a13f4bac53)
